### PR TITLE
fix params to support inputs from msg

### DIFF
--- a/node-red-contrib-ethers/node-ethers-transaction.html
+++ b/node-red-contrib-ethers/node-ethers-transaction.html
@@ -334,8 +334,8 @@
       ns.each(function(x) {
         const n = $(this)[0];
         const fieldIndex = parseInt(n.id.replace('node-input-param', ''));
-        const val = n.value;
-        paramsNew[fieldIndex] = val;
+        let foundType = $('#node-input-typeParam' + fieldIndex).val();
+        paramsNew[fieldIndex] = { type: foundType, val: n.value };
         // console.log('field', fieldIndex, val);
       });
 

--- a/node-red-contrib-ethers/node-ethers-transaction.js
+++ b/node-red-contrib-ethers/node-ethers-transaction.js
@@ -93,7 +93,10 @@ async function getABIFuncs(etherscanKey, network, address, abi) {
   var iface = new ethers.utils.Interface(abi2);
 
   // console.log('iface', iface.functions);
-  const abiFunctions = iface.abi.filter(x => x.type === 'function');
+  // const abiFunctions = iface.abi.filter(x => x.type === 'function');
+  const abiFunctions = Object.values(iface.functions).map( x => {
+    return JSON.parse(JSON.stringify(x));;
+  });
 
   return abiFunctions;
 }

--- a/node-red-contrib-ethers/node-ethers-transaction.js
+++ b/node-red-contrib-ethers/node-ethers-transaction.js
@@ -274,7 +274,7 @@ const inputMsg = async (RED, node, data, config) => {
   // node.log(tx);
   node.log(`result ${contractAddr}: "${result}"`);
 
-  let msg = {};
+  let msg = data || {};
   RED.util.setMessageProperty(msg, config.output || 'payload', result, true);
   // console.log('-', msg, config.output, result);
   // console.log('msgOutput');

--- a/node-red-contrib-ethers/node-ethers-transaction.js
+++ b/node-red-contrib-ethers/node-ethers-transaction.js
@@ -210,8 +210,14 @@ const inputMsg = async (RED, node, data, config) => {
   // const len = Math.max(configParams.length, payloadParams.length);
 
   let params = configParams.map((x, i) => {
-    if (x && x.indexOf('payload') === 0) {
+    if (typeof x != 'object' && x.indexOf('payload') === 0) {
       return RED.util.getMessageProperty(data, x);
+    } else if (typeof x == 'object') {
+      if (x.type.indexOf('msg') === 0) {
+        return RED.util.getMessageProperty(data, x.val);
+      } else {
+        return x.val;
+      }
     }
     return x;
   });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "author": "Jonathan Dunlap <jdunlap@outlook.com> (https://https://twitter.com/jadbox)",
     "description": "Simply call etherium contracts from node-red, powered by Ethers.js and Etherscan",
     "dependencies": {
-        "ethers": "^4.0.44",
+        "ethers": "^5.4.1",
         "etherscan-api": "^10.0.5"
     },
     "repository": {


### PR DESCRIPTION
When using msg._VARIABLE_ style inputs for contract params, it just uses the value as a string.
This fixes that behavior.